### PR TITLE
Add package closer, adapted to be used with Zap logger.

### DIFF
--- a/pkg/closer/closer.go
+++ b/pkg/closer/closer.go
@@ -1,0 +1,239 @@
+package closer
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"sync"
+	"syscall"
+
+	"go.uber.org/zap"
+)
+
+var (
+	// DebugSignalSet is a predefined list of signals to watch for. Usually
+	// these signals will terminate the app without executing the code in defer blocks.
+	DebugSignalSet = []os.Signal{
+		syscall.SIGINT,
+		syscall.SIGHUP,
+		syscall.SIGTERM,
+	}
+	// DefaultSignalSet will have syscall.SIGABRT that should be
+	// opted out if user wants to debug the stacktrace.
+	DefaultSignalSet = append(DebugSignalSet, syscall.SIGABRT)
+
+	// Logger defines the default Zap logger used for all the messages.
+	Logger, _ = zap.NewProduction()
+)
+
+var (
+	// ExitCodeOK is a successfull exit code.
+	ExitCodeOK = 0
+	// ExitCodeErr is a failure exit code.
+	ExitCodeErr = 1
+	// ExitSignals is the active list of signals to watch for.
+	ExitSignals = DefaultSignalSet
+)
+
+// Config should be used with Init function to override the defaults.
+type Config struct {
+	ExitCodeOK  int
+	ExitCodeErr int
+	ExitSignals []os.Signal
+}
+
+var c = newCloser()
+
+type closer struct {
+	codeOK     int
+	codeErr    int
+	signals    []os.Signal
+	sem        sync.Mutex
+	closeOnce  sync.Once
+	cleanups   []func()
+	errChan    chan struct{}
+	doneChan   chan struct{}
+	signalChan chan os.Signal
+	closeChan  chan struct{}
+	holdChan   chan struct{}
+
+	cancelWaitChan chan struct{}
+}
+
+func newCloser() *closer {
+	c := &closer{
+		codeOK:  ExitCodeOK,
+		codeErr: ExitCodeErr,
+		signals: ExitSignals,
+
+		errChan:    make(chan struct{}),
+		doneChan:   make(chan struct{}),
+		signalChan: make(chan os.Signal, 1),
+		closeChan:  make(chan struct{}),
+		holdChan:   make(chan struct{}),
+
+		cancelWaitChan: make(chan struct{}),
+	}
+
+	signal.Notify(c.signalChan, c.signals...)
+
+	// start waiting
+	go c.wait()
+	return c
+}
+
+func (c *closer) wait() {
+	exitCode := c.codeOK
+
+	// wait for a close request
+	select {
+	case <-c.cancelWaitChan:
+		return
+	case <-c.signalChan:
+	case <-c.closeChan:
+		break
+	case <-c.errChan:
+		exitCode = c.codeErr
+	}
+
+	// ensure we'll exit
+	defer os.Exit(exitCode)
+
+	c.sem.Lock()
+	defer c.sem.Unlock()
+	for _, fn := range c.cleanups {
+		fn()
+	}
+	// done!
+	close(c.doneChan)
+}
+
+// Close sends a close request.
+// The app will be terminated by OS as soon as the first close request will be handled by closer, this
+// function will return no sooner. The exit code will always be 0 (success).
+func Close() {
+	// check if there was a panic
+	if x := recover(); x != nil {
+		var (
+			offset int = 3
+			pc     uintptr
+			ok     bool
+		)
+
+		Logger.Info("run time panic:", zap.Any("error", x))
+
+		for offset < 32 {
+			pc, _, _, ok = runtime.Caller(offset)
+			if !ok {
+				// close with an error
+				c.closeErr()
+				return
+			}
+			frame := newStackFrame(pc)
+			fmt.Print(frame.String())
+			offset++
+		}
+
+		// close with an error
+		c.closeErr()
+		return
+	}
+
+	// normal close
+	c.closeOnce.Do(func() {
+		close(c.closeChan)
+	})
+
+	<-c.doneChan
+}
+
+// Fatalln works the same as log.Fatalln but respects the closer's logic.
+func Fatalln(v ...interface{}) {
+	Logger.WithOptions(zap.AddCallerSkip(2)).Error(fmt.Sprintln(v...))
+	c.closeErr()
+}
+
+// Fatalf works the same as log.Fatalf but respects the closer's logic.
+func Fatalf(format string, v ...interface{}) {
+	Logger.WithOptions(zap.AddCallerSkip(2)).Error(fmt.Sprintf(format, v...))
+	c.closeErr()
+}
+
+// Exit is the same as os.Exit but respects the closer's logic. It converts
+// any error code into ExitCodeErr (= 1, by default).
+func Exit(code int) {
+	// check if there was a panic
+	if x := recover(); x != nil {
+		var (
+			offset int = 3
+			pc     uintptr
+			ok     bool
+		)
+
+		Logger.Info("run time panic:", zap.Any("error", x))
+
+		for offset < 32 {
+			pc, _, _, ok = runtime.Caller(offset)
+			if !ok {
+				// close with an error
+				c.closeErr()
+				return
+			}
+			frame := newStackFrame(pc)
+			fmt.Print(frame.String())
+			offset++
+		}
+		// close with an error
+		c.closeErr()
+		return
+	}
+
+	if code == ExitCodeOK {
+		c.closeOnce.Do(func() {
+			close(c.closeChan)
+		})
+		<-c.doneChan
+		return
+	}
+
+	c.closeErr()
+}
+
+func (c *closer) closeErr() {
+	c.closeOnce.Do(func() {
+		close(c.errChan)
+	})
+
+	<-c.doneChan
+}
+
+// Init allows user to override the defaults (a set of OS signals to watch for, for example).
+func Init(cfg Config) {
+	c.sem.Lock()
+	signal.Stop(c.signalChan)
+	close(c.cancelWaitChan)
+	c.codeOK = cfg.ExitCodeOK
+	c.codeErr = cfg.ExitCodeErr
+	c.signals = cfg.ExitSignals
+	signal.Notify(c.signalChan, c.signals...)
+	go c.wait()
+	c.sem.Unlock()
+}
+
+// Bind will register the cleanup function that will be called when closer will get a close request.
+// All the callbacks will be called in the reverse order they were bound, that's similar to how `defer` works.
+func Bind(cleanup func()) {
+	c.sem.Lock()
+	// store in the reverse order
+	s := make([]func(), 0, 1+len(c.cleanups))
+	s = append(s, cleanup)
+	c.cleanups = append(s, c.cleanups...)
+	c.sem.Unlock()
+}
+
+// Hold is a helper that may be used to hold the main from returning,
+// until the closer will do a proper exit via `os.Exit`.
+func Hold() {
+	<-c.holdChan
+}

--- a/pkg/closer/doc.go
+++ b/pkg/closer/doc.go
@@ -1,0 +1,18 @@
+// Package closer ensures a clean exit for your Go app.
+//
+// The aim of this package is to provide an universal way to catch the event of application’s exit
+// and perform some actions before it’s too late. Closer doesn’t care about the way application
+// tries to exit, i.e. was that a panic or just a signal from the OS, it calls the provided methods
+// for cleanup and that’s the whole point.
+//
+// Exit codes
+//
+// The exit code (for `os.Exit`) will be determined accordingly:
+//
+//   Event         | Default exit code
+//   ------------- | -------------
+//   error = nil   | 0 (success)
+//   error != nil  | 1 (failure)
+//   panic         | 1 (failure)
+//
+package closer

--- a/pkg/closer/example_test.go
+++ b/pkg/closer/example_test.go
@@ -1,0 +1,27 @@
+package closer
+
+import (
+	"fmt"
+	"time"
+)
+
+// ExampleClose is an example of how to use closer in your main func.
+func ExampleClose() {
+	Bind(cleanupFunc)
+
+	go func() {
+		// do some pseudo background work
+		fmt.Println("10 seconds to go...")
+		time.Sleep(10 * time.Second)
+
+		Close()
+	}()
+
+	Hold()
+}
+
+func cleanupFunc() {
+	fmt.Print("Hang on! I'm closing some DBs, wiping some trails..")
+	time.Sleep(3 * time.Second)
+	fmt.Println("  Done.")
+}

--- a/pkg/closer/stackframes.go
+++ b/pkg/closer/stackframes.go
@@ -1,0 +1,100 @@
+// SEE https://github.com/bugsnag/bugsnag-go/blob/master/errors/stackframe.go
+// for the origin of this code
+
+package closer
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"strings"
+)
+
+// A StackFrame contains all necessary information about to generate a line
+// in a callstack.
+type StackFrame struct {
+	File           string
+	LineNumber     int
+	Name           string
+	Package        string
+	ProgramCounter uintptr
+}
+
+// newStackFrame populates a stack frame object from the program counter.
+func newStackFrame(pc uintptr) (frame StackFrame) {
+
+	frame = StackFrame{ProgramCounter: pc}
+	if frame.Func() == nil {
+		return
+	}
+	frame.Package, frame.Name = packageAndName(frame.Func())
+
+	// pc -1 because the program counters we use are usually return addresses,
+	// and we want to show the line that corresponds to the function call
+	frame.File, frame.LineNumber = frame.Func().FileLine(pc - 1)
+	return
+
+}
+
+// Func returns the function that this stackframe corresponds to
+func (frame *StackFrame) Func() *runtime.Func {
+	if frame.ProgramCounter == 0 {
+		return nil
+	}
+	return runtime.FuncForPC(frame.ProgramCounter)
+}
+
+// String returns the stackframe formatted in the same way as go does
+// in runtime/debug.Stack()
+func (frame *StackFrame) String() string {
+	str := fmt.Sprintf("%s:%d (0x%x)\n", frame.File, frame.LineNumber, frame.ProgramCounter)
+
+	source, err := frame.SourceLine()
+	if err != nil {
+		return str
+	}
+
+	return str + fmt.Sprintf("\t%s: %s\n", frame.Name, source)
+}
+
+// SourceLine gets the line of code (from File and Line) of the original source if possible
+func (frame *StackFrame) SourceLine() (string, error) {
+	data, err := ioutil.ReadFile(frame.File)
+
+	if err != nil {
+		return "", err
+	}
+
+	lines := bytes.Split(data, []byte{'\n'})
+	if frame.LineNumber <= 0 || frame.LineNumber >= len(lines) {
+		return "???", nil
+	}
+	// -1 because line-numbers are 1 based, but our array is 0 based
+	return string(bytes.Trim(lines[frame.LineNumber-1], " \t")), nil
+}
+
+func packageAndName(fn *runtime.Func) (string, string) {
+	name := fn.Name()
+	pkg := ""
+
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//  runtime/debug.*T·ptrmethod
+	// and want
+	//  *T.ptrmethod
+	// Since the package path might contains dots (e.g. code.google.com/...),
+	// we first remove the path prefix if there is one.
+	if lastslash := strings.LastIndex(name, "/"); lastslash >= 0 {
+		pkg += name[:lastslash] + "/"
+		name = name[lastslash+1:]
+	}
+	if period := strings.Index(name, "."); period >= 0 {
+		pkg += name[:period]
+		name = name[period+1:]
+	}
+
+	name = strings.Replace(name, "·", ".", -1)
+	return pkg, name
+}


### PR DESCRIPTION
Adding another package converted from external opensourced and bullet-proof version ([closer](https://github.com/xlab/closer), with changes to our Zap logging chain.

The package solves a simple problem: allows to quit app gracefully, with chain of cleanup functions.
The graceful exit shall be guaranteed for a list of system signals (like `SIGINT` etc), as well as any `panic`s reaching the `main` func.

**Usage pattern is like this:**

```go
func main() {
	defer closer.Close() // ensures we catch panics

	closer.Bind(func() {
		fmt.Println("I'm the cleanup chain! Step 2")
	})

	closer.Bind(func() {
		fmt.Println("I'm the cleanup chain! Step 1")
	})

	go doStuff()

	closer.Hold() // It just blocks until you press ^C etc
}
```

An example use case can be seen there:
https://github.com/CoreumFoundation/coreum/blob/c66f9630571bd7548a99030edfab3d2611dcae6e/coremon/cmd/coremon/cmd_process.go#L34-L40

The reason why I bringing this package there is because I don't want to have full IoC stuff dependency from znet just to handle graceful shutdowns upon signals, as can be seen there in `coreznet`:
https://github.com/CoreumFoundation/coreum-tools/blob/f8569e99fad668523fb29ffd200d7b890746e8c2/pkg/run/run.go#L72-L73
(which brings reflection, metaprogramming, goroutine manager parallel spawning, singletons and other IoC-related stuff on the plate for some reason)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum-tools/10)
<!-- Reviewable:end -->
