### PR TITLE
Copy `retry` package from `crust`

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,70 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/CoreumFoundation/coreum-tools/pkg/logger"
+)
+
+// Retryable returns retryable error
+func Retryable(err error) error {
+	if err == nil {
+		return nil
+	}
+	return RetryableError{err: err}
+}
+
+// RetryableError represents retryable error
+type RetryableError struct {
+	err error
+}
+
+// Error returns string representation of error
+func (e RetryableError) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap returns next error
+func (e RetryableError) Unwrap() error {
+	return e.err
+}
+
+// Do retries running function until it returns non-retryable error
+func Do(ctx context.Context, retryAfter time.Duration, fn func() error) error {
+	log := logger.Get(ctx)
+	var lastMessage string
+	var r RetryableError
+	for {
+		var r2 RetryableError
+		if err := fn(); !errors.As(err, &r2) {
+			return err
+		}
+		if errors.Is(r2.err, ctx.Err()) {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) && r.err != nil {
+				return r.err
+			}
+			return r2.err
+		}
+		r = r2
+
+		newMessage := r.err.Error()
+		if lastMessage != newMessage {
+			log.Debug(fmt.Sprintf("Will retry: %s", newMessage), zap.Error(r.err))
+			lastMessage = newMessage
+		}
+
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return r.err
+			}
+			return errors.WithStack(ctx.Err())
+		case <-time.After(retryAfter):
+		}
+	}
+}


### PR DESCRIPTION
This package is used by cored client in `crust`. That client will be moved to `coreum`. Which means `retry` will be used by both repos, that's why it is moved to common place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum-tools/13)
<!-- Reviewable:end -->
