### PR TITLE
Downgrade go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CoreumFoundation/coreum-tools
 
-go 1.17
+go 1.16
 
 require (
 	github.com/pkg/errors v0.9.1
@@ -10,9 +10,6 @@ require (
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
`coreum` uses go 1.16 so this repo can't use 1.17

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coreumfoundation/coreum-tools/14)
<!-- Reviewable:end -->
