### PR TITLE
Restore Debug level logging for the task finishing error.

### DIFF
--- a/pkg/parallel/group.go
+++ b/pkg/parallel/group.go
@@ -143,7 +143,7 @@ func (g *Group) Spawn(name string, onExit OnExit, task Task) {
 func (g *Group) runTask(ctx context.Context, name string, id int64, onExit OnExit, task Task) {
 	err := runTaskWithRecovery(ctx, g.log, name, id, onExit, task)
 	if err != nil {
-		g.log.Error(
+		g.log.Debug(
 			ctx,
 			"Task finished with error",
 			zap.String("name", name),


### PR DESCRIPTION
Restore Debug level logging for the task finishing error to prevent double logging and logging of the context canceled errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CoreumFoundation/coreum-tools/28)
<!-- Reviewable:end -->
